### PR TITLE
fix(pluginManager): plugin event/listen handlers never fire (shadowed in dispatcher group 0)

### DIFF
--- a/src/utils/pluginManager.ts
+++ b/src/utils/pluginManager.ts
@@ -377,10 +377,29 @@ async function runPluginSetup(plugin: Plugin, runtime: TeleBoxRuntime): Promise<
   );
 }
 
+// mtcute's Dispatcher runs, within a single handler group, ONLY the first
+// matching handler and then stops propagation unless that handler returns
+// PropagationAction.Continue. The root command router (registered in group 0
+// before this function runs) matches every message and returns void, which
+// would shadow every plugin listen/event handler that also landed in group 0 —
+// they would silently never fire. Give each plugin's listen/event handlers
+// their own dedicated, monotonically increasing handler group: mtcute iterates
+// all groups in order, so every plugin group runs independently of the root
+// router and of each other. Group 0 stays reserved for the root command router.
+let pluginHandlerGroupSeq = 0;
+function nextPluginHandlerGroup(): number {
+  return ++pluginHandlerGroupSeq;
+}
+
 function dealListenMessagePlugin(runtime: TeleBoxRuntime, dispatcher: Dispatcher): void {
+  // Each runtime generation rebuilds the dispatcher from scratch, so reset the
+  // group counter to keep group numbers stable and bounded across reloads.
+  pluginHandlerGroupSeq = 0;
+
   for (const plugin of validPlugins) {
     const messageHandler = plugin.listenMessageHandler;
     if (messageHandler) {
+      const group = nextPluginHandlerGroup();
       dispatcher.onNewMessage(async (msg: MessageContext) => {
         if (runtime.generation !== getCurrentGeneration()) return;
         try {
@@ -388,7 +407,7 @@ function dealListenMessagePlugin(runtime: TeleBoxRuntime, dispatcher: Dispatcher
         } catch (error: unknown) {
           logger.error("listenMessageHandler NewMessage error:", error);
         }
-      });
+      }, group);
 
       if (
         !plugin.listenMessageHandlerIgnoreEdited ||
@@ -401,7 +420,7 @@ function dealListenMessagePlugin(runtime: TeleBoxRuntime, dispatcher: Dispatcher
           } catch (error: unknown) {
             logger.error("listenMessageHandler EditedMessage error:", error);
           }
-        });
+        }, group);
       }
     }
 
@@ -411,6 +430,7 @@ function dealListenMessagePlugin(runtime: TeleBoxRuntime, dispatcher: Dispatcher
     const eventHandlers = plugin.eventHandlers;
     if (Array.isArray(eventHandlers) && eventHandlers.length > 0) {
       for (const eh of eventHandlers) {
+        const group = nextPluginHandlerGroup();
         const safeHandler = async (ctx: unknown) => {
           if (runtime.generation !== getCurrentGeneration()) return;
           try {
@@ -421,14 +441,14 @@ function dealListenMessagePlugin(runtime: TeleBoxRuntime, dispatcher: Dispatcher
         };
         switch (eh.kind) {
           case "editMessage":
-            dispatcher.onEditMessage((msg: MessageContext) => safeHandler(msg));
+            dispatcher.onEditMessage((msg: MessageContext) => safeHandler(msg), group);
             break;
           case "rawUpdate":
-            dispatcher.onRawUpdate((upd: unknown) => safeHandler(upd));
+            dispatcher.onRawUpdate((upd: unknown) => safeHandler(upd), group);
             break;
           case "newMessage":
           default:
-            dispatcher.onNewMessage((msg: MessageContext) => safeHandler(msg));
+            dispatcher.onNewMessage((msg: MessageContext) => safeHandler(msg), group);
             break;
         }
       }


### PR DESCRIPTION
## Problem

Plugin `listenMessageHandler` and `eventHandlers` (e.g. `eventHandlers = [{ kind: "newMessage", handler }]`) silently never fire. The plugin loads fine, `cmdHandlers` work, but event-driven handlers receive nothing.

## Root cause

`dealListenMessagePlugin()` registers every plugin listen/event handler into mtcute Dispatcher **group 0** — the same group as the root command router registered just above it in `loadPluginsForRuntime()`.

mtcute (`@mtcute/dispatcher` 0.31.0) runs, within a single handler group, **only the first matching handler** and then stops propagation unless that handler returns `PropagationAction.Continue`. See the per-group loop in `dispatcher.js` — it `break`s after the first handler whose `check` passes:

```js
outer: for (const grp of this._groupsOrder) {
  const group = this._groups.get(grp);
  if (group.has(update.name)) {
    const handlers = group.get(update.name);
    for (const h of handlers) {
      if (!h.check || await h.check(...)) {
        result = await h.callback(...);   // root router runs here
        handled = true;
      } else { continue; }
      switch (result) {
        case "continue": continue;
        // ...
      }
      break;   // <-- stops after the first matching handler
    }
  }
}
```

The root command router (`dispatcher.onNewMessage(... dealNewMsgEvent ...)`) is registered first in group 0, matches every message, and returns `void`. So it satisfies the loop and `break`s before any plugin handler in group 0 is reached.

`cmdHandlers` are unaffected because they are invoked *by* the root router, not via their own dispatcher handlers. Only event-driven plugins hit this — which is why the framework’s own mostly-command-based plugins never surfaced it.

## Fix

Give each plugin’s listen/event handlers their own dedicated, monotonically increasing handler **group**. mtcute iterates all groups in order (`_groupsOrder`), so every plugin group runs independently of the root router and of each other. Group 0 stays reserved for the root command router. The counter resets per runtime generation since the dispatcher is rebuilt on reload.

`onNewMessage` / `onEditMessage` / `onRawUpdate` all accept an optional trailing `group` argument in the installed mtcute version, so this is a minimal change.

## Test plan

- [x] Transpiles clean (esbuild syntax gate)
- [x] Verified against `@mtcute/dispatcher` 0.31.0 that the `group` argument exists on `onNewMessage`/`onEditMessage`/`onRawUpdate`
- [x] Verified in production: an anti-PM plugin using `eventHandlers[{ kind: "newMessage" }]` went from never firing to correctly deleting + blocking incoming PMs after this change