### PR TITLE
fix: restore missing panel menu button module

### DIFF
--- a/src/utils/panel/menuButton.ts
+++ b/src/utils/panel/menuButton.ts
@@ -1,0 +1,152 @@
+/**
+ * TeleBox Panel — Telegram Chat Menu Button integration.
+ *
+ * This module is intentionally independent from botService: botService imports
+ * webAppUrl() to build inline buttons, while the controller passes the active
+ * Telegraf instance here for the default Chat Menu Button.
+ */
+
+import type { Telegraf } from "telegraf";
+import { getErrorMessage } from "@utils/errorHelpers";
+import { logger } from "@utils/logger";
+import type { PanelConfig } from "./types";
+
+type SetChatMenuButtonOptions = NonNullable<
+  Parameters<Telegraf["telegram"]["setChatMenuButton"]>[0]
+>;
+type MenuButton = NonNullable<SetChatMenuButtonOptions["menuButton"]>;
+
+export interface MenuButtonState {
+  bound: boolean;
+  /** The URL from the last successful WebApp binding, or empty when unbound. */
+  url: string;
+  /** The last binding/clearing failure, if any. */
+  error?: string;
+}
+
+const MENU_BUTTON_TEXT = "打开管理面板";
+
+let state: MenuButtonState = {
+  bound: false,
+  url: "",
+};
+
+/**
+ * Normalize the URL shared by inline WebApp buttons and the Chat Menu Button.
+ * Config storage already removes trailing slashes, but this helper is also
+ * called directly by botService and therefore remains defensive.
+ */
+export function webAppUrl(baseUrl: string): string {
+  const value = baseUrl.trim();
+  return value ? value.replace(/\/+$/, "") : "";
+}
+
+export function getMenuButtonState(): MenuButtonState {
+  return { ...state };
+}
+
+function setUnbound(error?: string): void {
+  state = error
+    ? { bound: false, url: "", error }
+    : { bound: false, url: "" };
+}
+
+function setBound(url: string): void {
+  state = { bound: true, url };
+}
+
+function validateWebAppUrl(baseUrl: string): string {
+  const url = webAppUrl(baseUrl);
+  if (!url) {
+    throw new Error("未设置公网 HTTPS 地址");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("公网地址格式无效");
+  }
+
+  if (parsed.protocol !== "https:" || !parsed.hostname) {
+    throw new Error("Telegram WebApp 要求 https:// 公网地址");
+  }
+  return url;
+}
+
+function defaultMenuButton(): MenuButton {
+  return { type: "default" };
+}
+
+function webAppMenuButton(url: string): MenuButton {
+  return {
+    type: "web_app",
+    text: MENU_BUTTON_TEXT,
+    web_app: { url },
+  };
+}
+
+/**
+ * Restore Telegram's normal command-list menu button.
+ *
+ * Clearing is best-effort during shutdown: a missing bot instance is already
+ * equivalent to no active binding in this process, while a live Bot API error
+ * remains visible through getMenuButtonState().
+ */
+export async function clearMenuButton(bot: Telegraf | null): Promise<void> {
+  if (!bot) {
+    setUnbound();
+    return;
+  }
+
+  try {
+    await bot.telegram.setChatMenuButton({
+      menuButton: defaultMenuButton(),
+    });
+    setUnbound();
+  } catch (error: unknown) {
+    const message = getErrorMessage(error);
+    setUnbound(message);
+    logger.warn("[panel-menu] failed to restore Telegram default menu button", error);
+  }
+}
+
+/**
+ * Synchronize the default Chat Menu Button with the current panel config.
+ * Invalid/empty URLs clear any stale button and remain observable as state;
+ * they do not prevent the rest of the panel runtime from starting.
+ */
+export async function applyMenuButton(
+  bot: Telegraf | null,
+  cfg: PanelConfig,
+): Promise<void> {
+  if (!cfg.enabled || !cfg.publicBaseUrl.trim()) {
+    await clearMenuButton(bot);
+    return;
+  }
+
+  let url: string;
+  try {
+    url = validateWebAppUrl(cfg.publicBaseUrl);
+  } catch (error: unknown) {
+    await clearMenuButton(bot);
+    setUnbound(getErrorMessage(error));
+    return;
+  }
+
+  if (!bot) {
+    setUnbound("Bot 未运行");
+    return;
+  }
+
+  try {
+    await bot.telegram.setChatMenuButton({
+      menuButton: webAppMenuButton(url),
+    });
+    setBound(url);
+  } catch (error: unknown) {
+    const message = getErrorMessage(error);
+    setUnbound(message);
+    logger.warn("[panel-menu] failed to bind Telegram WebApp menu button", error);
+  }
+}

--- a/tests/panelMenuButton.test.ts
+++ b/tests/panelMenuButton.test.ts
@@ -1,0 +1,126 @@
+import type { Telegraf } from "telegraf";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PanelConfig } from "../src/utils/panel/types";
+import {
+  applyMenuButton,
+  clearMenuButton,
+  getMenuButtonState,
+  webAppUrl,
+} from "../src/utils/panel/menuButton";
+
+function config(patch: Partial<PanelConfig> = {}): PanelConfig {
+  return {
+    enabled: true,
+    botToken: "123:token",
+    publicBaseUrl: "https://panel.example.com",
+    bindHost: "0.0.0.0",
+    bindPort: 8787,
+    sessionSecret: "x".repeat(64),
+    admins: [],
+    displayName: "Panel",
+    updatedAt: 0,
+    tunnelMode: "off",
+    tunnelUrl: "",
+    ...patch,
+  };
+}
+
+function fakeBot(
+  setChatMenuButton = vi.fn().mockResolvedValue(true),
+): Telegraf {
+  return {
+    telegram: { setChatMenuButton },
+  } as unknown as Telegraf;
+}
+
+describe("panel menu button", () => {
+  beforeEach(async () => {
+    await clearMenuButton(null);
+  });
+
+  it("normalizes the public base URL for both WebApp entry points", () => {
+    expect(webAppUrl("  https://panel.example.com///  ")).toBe(
+      "https://panel.example.com",
+    );
+  });
+
+  it("binds a valid HTTPS WebApp as the default menu button", async () => {
+    const setChatMenuButton = vi.fn().mockResolvedValue(true);
+    await applyMenuButton(
+      fakeBot(setChatMenuButton),
+      config({ publicBaseUrl: "https://panel.example.com/" }),
+    );
+
+    expect(setChatMenuButton).toHaveBeenCalledWith({
+      menuButton: {
+        type: "web_app",
+        text: "打开管理面板",
+        web_app: { url: "https://panel.example.com" },
+      },
+    });
+    expect(getMenuButtonState()).toEqual({
+      bound: true,
+      url: "https://panel.example.com",
+    });
+  });
+
+  it("restores Telegram's default menu when the panel is disabled or has no URL", async () => {
+    const setChatMenuButton = vi.fn().mockResolvedValue(true);
+    await applyMenuButton(
+      fakeBot(setChatMenuButton),
+      config({ enabled: false }),
+    );
+    await applyMenuButton(
+      fakeBot(setChatMenuButton),
+      config({ publicBaseUrl: "" }),
+    );
+
+    expect(setChatMenuButton).toHaveBeenNthCalledWith(1, {
+      menuButton: { type: "default" },
+    });
+    expect(setChatMenuButton).toHaveBeenNthCalledWith(2, {
+      menuButton: { type: "default" },
+    });
+    expect(getMenuButtonState()).toEqual({ bound: false, url: "" });
+  });
+
+  it("clears an invalid URL and exposes the validation error", async () => {
+    const setChatMenuButton = vi.fn().mockResolvedValue(true);
+    await applyMenuButton(
+      fakeBot(setChatMenuButton),
+      config({ publicBaseUrl: "http://panel.example.com" }),
+    );
+
+    expect(setChatMenuButton).toHaveBeenCalledWith({
+      menuButton: { type: "default" },
+    });
+    expect(getMenuButtonState()).toMatchObject({
+      bound: false,
+      url: "",
+    });
+    expect(getMenuButtonState().error).toContain("https://");
+  });
+
+  it("retains an API failure as observable state instead of claiming success", async () => {
+    const setChatMenuButton = vi
+      .fn()
+      .mockRejectedValue(new Error("Telegram API unavailable"));
+    await applyMenuButton(fakeBot(setChatMenuButton), config());
+
+    expect(getMenuButtonState()).toEqual({
+      bound: false,
+      url: "",
+      error: "Telegram API unavailable",
+    });
+  });
+
+  it("reports that an enabled panel cannot bind without a running bot", async () => {
+    await applyMenuButton(null, config());
+
+    expect(getMenuButtonState()).toEqual({
+      bound: false,
+      url: "",
+      error: "Bot 未运行",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Restore the missing `src/utils/panel/menuButton.ts` module.
- Add behavioral regression tests for Telegram WebApp menu-button binding.

## Problem

The current `main` branch references `@utils/panel/menuButton` from `src/plugin/panel.ts` and `./menuButton` from the Panel services, but the module is absent from the repository. A clean TypeScript check therefore fails with four `TS2307` module-resolution errors.

## Root cause

The Panel call sites already depend on four functions:

- `webAppUrl`
- `getMenuButtonState`
- `applyMenuButton`
- `clearMenuButton`

The missing module leaves both the Panel runtime contract and the TypeScript build incomplete.

## Implementation

- Normalize the public WebApp URL and remove trailing slashes.
- Bind a valid HTTPS URL as Telegram's default WebApp menu button.
- Restore Telegram's default menu button when the Panel is disabled or has no URL.
- Reject invalid/non-HTTPS URLs without leaving a stale binding.
- Preserve Telegram API and missing-Bot failures in the observable menu-button state and log the API failure.
- Keep the module independent from `botService` to avoid a circular dependency.

The default behavior remains compatible: when the Panel is disabled or no public URL is configured, the normal Telegram menu is restored.

## Verification

Run from a clean contribution checkout based on `upstream/main`:

```text
Focused Panel menu-button tests: 6 passed
Full upstream Vitest suite: 36 passed
TypeScript no-emit check: passed
```

The test runner emitted the repository's existing Vite CommonJS/ESM configuration warning; it did not affect the test result.
